### PR TITLE
[pyflakes] Fix missing import submodules

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_30.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F821_30.py
@@ -1,0 +1,5 @@
+import foo.bar
+import foo.ban
+
+def fu(zxc):
+    foo.bag.get(zxc)

--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -1114,6 +1114,15 @@ impl<'a> Visitor<'a> for Checker<'a> {
                     }
                 }
             }
+            Expr::Attribute(ast::ExprAttribute {
+                value: _,
+                range: _,
+                ctx,
+                attr: _,
+            }) => match ctx {
+                ExprContext::Load => self.handle_attribute_load(expr),
+                _ => {}
+            },
             Expr::Name(ast::ExprName { id, ctx, range: _ }) => match ctx {
                 ExprContext::Load => self.handle_node_load(expr),
                 ExprContext::Store => self.handle_node_store(id, expr),
@@ -1978,6 +1987,13 @@ impl<'a> Checker<'a> {
             return;
         };
         self.semantic.resolve_load(expr);
+    }
+
+    fn handle_attribute_load(&mut self, expr: &Expr) {
+        let Expr::Attribute(expr) = expr else {
+            return;
+        };
+        self.semantic.resolve_attribute_load(expr);
     }
 
     fn handle_node_store(&mut self, id: &'a str, expr: &Expr) {

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -2654,7 +2654,7 @@ lambda: fu
         import foo.baz as foo
         foo
         ",
-            &[Rule::RedefinedWhileUnused],
+            &[Rule::UnusedImport, Rule::RedefinedWhileUnused],
         );
     }
 
@@ -2704,13 +2704,13 @@ lambda: fu
 
     #[test]
     fn unused_package_with_submodule_import() {
-        // When a package and its submodule are imported, only report once.
+        // When a package and its submodule are imported, report both.
         flakes(
             r"
         import fu
         import fu.bar
         ",
-            &[Rule::UnusedImport],
+            &[Rule::UnusedImport, Rule::UnusedImport],
         );
     }
 

--- a/crates/ruff_linter/src/rules/pyflakes/mod.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/mod.rs
@@ -161,6 +161,7 @@ mod tests {
     #[test_case(Rule::UndefinedName, Path::new("F821_26.pyi"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_27.py"))]
     #[test_case(Rule::UndefinedName, Path::new("F821_28.py"))]
+    #[test_case(Rule::UndefinedName, Path::new("F821_30.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.py"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_0.pyi"))]
     #[test_case(Rule::UndefinedExport, Path::new("F822_1.py"))]

--- a/crates/ruff_linter/src/rules/pyflakes/rules/undefined_local.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/undefined_local.rs
@@ -3,6 +3,7 @@ use std::string::ToString;
 use ruff_diagnostics::{Diagnostic, Violation};
 use ruff_macros::{derive_message_formats, violation};
 use ruff_python_semantic::{Scope, ScopeId};
+use ruff_python_semantic::BindingKind::SubmoduleImport;
 use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
@@ -61,7 +62,12 @@ pub(crate) fn undefined_local(
                 if let Some(range) = shadowed.references().find_map(|reference_id| {
                     let reference = checker.semantic().reference(reference_id);
                     if reference.scope_id() == scope_id {
-                        Some(reference.range())
+                        // FIXME: ignore submodules
+                        if let SubmoduleImport(..) = shadowed.kind {
+                            None
+                        } else {
+                            Some(reference.range())
+                        }
                     } else {
                         None
                     }

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_0.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F401_F401_0.py.snap
@@ -39,6 +39,46 @@ F401_0.py:6:5: F401 [*] `collections.OrderedDict` imported but unused
 8 7 | )
 9 8 | import multiprocessing.pool
 
+F401_0.py:10:8: F401 [*] `multiprocessing.process` imported but unused
+   |
+ 8 | )
+ 9 | import multiprocessing.pool
+10 | import multiprocessing.process
+   |        ^^^^^^^^^^^^^^^^^^^^^^^ F401
+11 | import logging.config
+12 | import logging.handlers
+   |
+   = help: Remove unused import: `multiprocessing.process`
+
+ℹ Safe fix
+7  7  |     namedtuple,
+8  8  | )
+9  9  | import multiprocessing.pool
+10    |-import multiprocessing.process
+11 10 | import logging.config
+12 11 | import logging.handlers
+13 12 | from typing import (
+
+F401_0.py:11:8: F401 [*] `logging.config` imported but unused
+   |
+ 9 | import multiprocessing.pool
+10 | import multiprocessing.process
+11 | import logging.config
+   |        ^^^^^^^^^^^^^^ F401
+12 | import logging.handlers
+13 | from typing import (
+   |
+   = help: Remove unused import: `logging.config`
+
+ℹ Safe fix
+8  8  | )
+9  9  | import multiprocessing.pool
+10 10 | import multiprocessing.process
+11    |-import logging.config
+12 11 | import logging.handlers
+13 12 | from typing import (
+14 13 |     TYPE_CHECKING,
+
 F401_0.py:12:8: F401 [*] `logging.handlers` imported but unused
    |
 10 | import multiprocessing.process
@@ -282,5 +322,3 @@ F401_0.py:122:1: F401 [*] `datameta_client_lib.model_helpers.noqa` imported but 
 120 120 | 
 121     |-from datameta_client_lib.model_helpers import (
 122     |-noqa )
-
-

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_30.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F821_F821_30.py.snap
@@ -1,0 +1,9 @@
+---
+source: crates/ruff_linter/src/rules/pyflakes/mod.rs
+---
+F821_30.py:5:5: F821 Undefined name `foo.bag.get`
+  |
+4 | def fu(zxc):
+5 |     foo.bag.get(zxc)
+  |     ^^^^^^^^^^^ F821
+  |

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::Path;
 
 use bitflags::bitflags;
@@ -5,7 +6,7 @@ use rustc_hash::FxHashMap;
 
 use ruff_python_ast::helpers::from_relative_import;
 use ruff_python_ast::name::{QualifiedName, UnqualifiedName};
-use ruff_python_ast::{self as ast, Expr, ExprContext, Operator, PySourceType, Stmt};
+use ruff_python_ast::{self as ast, Expr, ExprContext, ExprName, Operator, PySourceType, Stmt};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::binding::{
@@ -352,10 +353,274 @@ impl<'a> SemanticModel<'a> {
         }
     }
 
+    fn resolve_binding(
+        &mut self,
+        binding_id: BindingId,
+        name_expr: &ExprName,
+        scope_id: &ScopeId,
+    ) -> Option<ReadResult>
+    {
+
+        let reference_id = self.resolved_references.push(
+            self.scope_id,
+            self.node_id,
+            ExprContext::Load,
+            self.flags,
+            name_expr.range,
+        );
+
+        self.bindings[binding_id].references.push(reference_id);
+
+        if let Some(binding_id) = self.resolve_submodule(
+            name_expr.id.as_str(),
+            *scope_id,
+            binding_id,
+        ) {
+            let reference_id = self.resolved_references.push(
+                self.scope_id,
+                self.node_id,
+                ExprContext::Load,
+                self.flags,
+                name_expr.range,
+            );
+            self.bindings[binding_id].references.push(reference_id);
+        }
+
+        match self.bindings[binding_id].kind {
+            // If it's a type annotation, don't treat it as resolved. For example, given:
+            //
+            // ```python
+            // name: str
+            // print(name)
+            // ```
+            //
+            // The `name` in `print(name)` should be treated as unresolved, but the `name` in
+            // `name: str` should be treated as used.
+            //
+            // Stub files are an exception. In a stub file, it _is_ considered valid to
+            // resolve to a type annotation.
+            BindingKind::Annotation if !self.in_stub_file() => None,
+
+            // If it's a deletion, don't treat it as resolved, since the name is now
+            // unbound. For example, given:
+            //
+            // ```python
+            // x = 1
+            // del x
+            // print(x)
+            // ```
+            //
+            // The `x` in `print(x)` should be treated as unresolved.
+            //
+            // Similarly, given:
+            //
+            // ```python
+            // try:
+            //     pass
+            // except ValueError as x:
+            //     pass
+            //
+            // print(x)
+            //
+            // The `x` in `print(x)` should be treated as unresolved.
+            BindingKind::Deletion | BindingKind::UnboundException(None) => {
+                self.unresolved_references.push(
+                    name_expr.range,
+                    self.exceptions(),
+                    UnresolvedReferenceFlags::empty(),
+                );
+                Some(ReadResult::UnboundLocal(binding_id))
+            }
+
+            BindingKind::ConditionalDeletion(binding_id) => {
+                self.unresolved_references.push(
+                    name_expr.range,
+                    self.exceptions(),
+                    UnresolvedReferenceFlags::empty(),
+                );
+                Some(ReadResult::UnboundLocal(binding_id))
+            }
+
+            // If we hit an unbound exception that shadowed a bound name, resole to the
+            // bound name. For example, given:
+            //
+            // ```python
+            // x = 1
+            //
+            // try:
+            //     pass
+            // except ValueError as x:
+            //     pass
+            //
+            // print(x)
+            // ```
+            //
+            // The `x` in `print(x)` should resolve to the `x` in `x = 1`.
+            BindingKind::UnboundException(Some(binding_id)) => {
+                // Mark the binding as used.
+                let reference_id = self.resolved_references.push(
+                    self.scope_id,
+                    self.node_id,
+                    ExprContext::Load,
+                    self.flags,
+                    name_expr.range,
+                );
+                self.bindings[binding_id].references.push(reference_id);
+
+                // Mark any submodule aliases as used.
+                if let Some(binding_id) = self.resolve_submodule(
+                    name_expr.id.as_str(),
+                    *scope_id,
+                    binding_id,
+                ) {
+                    let reference_id = self.resolved_references.push(
+                        self.scope_id,
+                        self.node_id,
+                        ExprContext::Load,
+                        self.flags,
+                        name_expr.range,
+                    );
+                    self.bindings[binding_id].references.push(reference_id);
+                }
+
+                self.resolved_names
+                    .insert(name_expr.into(), binding_id);
+                Some(ReadResult::Resolved(binding_id))
+            }
+
+            BindingKind::Global(Some(binding_id))
+            | BindingKind::Nonlocal(binding_id, _) => {
+                // Mark the shadowed binding as used.
+                let reference_id = self.resolved_references.push(
+                    self.scope_id,
+                    self.node_id,
+                    ExprContext::Load,
+                    self.flags,
+                    name_expr.range,
+                );
+                self.bindings[binding_id].references.push(reference_id);
+
+                // Treat it as resolved.
+                self.resolved_names
+                    .insert(name_expr.into(), binding_id);
+                Some(ReadResult::Resolved(binding_id))
+            }
+
+            _ => {
+                // Otherwise, treat it as resolved.
+                self.resolved_names
+                    .insert(name_expr.into(), binding_id);
+                Some(ReadResult::Resolved(binding_id))
+            }
+        }
+    }
+
+    /// Resolve a `load` reference to an [`ast::ExprAttribute`].
+    pub fn resolve_attribute_load(&mut self, attribute: &ast::ExprAttribute) -> ReadResult {
+        let name_expr;
+
+        let mut full_name = format!("{}", attribute.attr.id);
+        let mut current_expr = &*attribute.value;
+        let mut result = None;
+        let mut is_name_exist = false;
+        let mut already_checked_imports: HashSet<String> = HashSet::new();
+
+        while let Expr::Attribute(expr_attr) = &current_expr {
+            full_name = format!("{}.{}", expr_attr.attr.id, full_name);
+            current_expr = &*expr_attr.value;
+        }
+
+        if let Expr::Name(ref expr_name) = current_expr {
+            full_name = format!("{}.{}", expr_name.id, full_name);
+            name_expr = Some(expr_name);
+        } else {
+            return ReadResult::NotFound;
+        }
+
+        if name_expr.is_none() {
+            return ReadResult::NotFound;
+        }
+
+        full_name = full_name.trim_end_matches('.').to_string();
+
+        let ancestor_scope_ids: Vec<_> = self.scopes.ancestor_ids(self.scope_id).collect();
+        let mut binding_ids: Vec<(BindingId, ScopeId)> = vec![];
+
+        for (_index, scope_id) in ancestor_scope_ids.into_iter().enumerate() {
+            for binding_id in self.scopes[scope_id].get_all(name_expr.unwrap().id.as_str()){
+                binding_ids.push((binding_id, scope_id));
+            }
+        }
+
+        for (binding_id, scope_id) in binding_ids.iter() {
+            if let BindingKind::SubmoduleImport(binding_kind) = &self.binding(*binding_id).kind
+            {
+                if binding_kind.qualified_name.to_string() == full_name {
+                    if let Some(result) = self.resolve_binding(
+                        *binding_id,
+                        &name_expr.unwrap(),
+                        scope_id,
+                    ) {
+                        return result;
+                    }
+                }
+            }
+            if let BindingKind::Import(_) = &self.binding(*binding_id).kind {
+                is_name_exist = true;
+            }
+        }
+
+        // TODO: need to move the block implementation to resolve_load, but carefully
+        // start check module import
+        for (binding_id, scope_id) in binding_ids.iter() {
+            let Some(import) = self.binding(*binding_id).as_any_import() else {
+                continue;
+            };
+            let name = &import.qualified_name().to_string()
+                .split(".").next().unwrap_or("").to_owned();
+
+            match self.bindings[*binding_id].kind {
+                BindingKind::SubmoduleImport(_) if !is_name_exist => continue,
+                BindingKind::WithItemVar => continue,
+                BindingKind::SubmoduleImport(_) => {
+                    result = self.resolve_binding(
+                        *binding_id,
+                        &name_expr.unwrap(),
+                        scope_id,
+                    );
+                },
+                BindingKind::Import(_) => {
+
+                    if already_checked_imports.contains(&name.to_string())
+                    {
+                        continue;
+                    } else {
+                        already_checked_imports.insert(name.to_string());
+                    }
+
+                    result = self.resolve_binding(
+                        *binding_id,
+                        &name_expr.unwrap(),
+                        scope_id,
+                    );
+                }
+                _ => {}
+            }
+        }
+        // end check module import
+
+        if result.is_none() {
+            ReadResult::NotFound
+        } else {
+            result.unwrap()
+        }
+    }
+
     /// Resolve a `load` reference to an [`ast::ExprName`].
     pub fn resolve_load(&mut self, name: &ast::ExprName) -> ReadResult {
         // PEP 563 indicates that if a forward reference can be resolved in the module scope, we
         // should prefer it over local resolutions.
+
         if self.in_forward_reference() {
             if let Some(binding_id) = self.scopes.global().get(name.id.as_str()) {
                 if !self.bindings[binding_id].is_unbound() {
@@ -392,9 +657,18 @@ impl<'a> SemanticModel<'a> {
         let mut seen_function = false;
         let mut import_starred = false;
         let mut class_variables_visible = true;
-        for (index, scope_id) in self.scopes.ancestor_ids(self.scope_id).enumerate() {
+        let mut result = None;
+
+        let ancestor_scope_ids: Vec<_> = self.scopes.ancestor_ids(self.scope_id).collect();
+
+        for (index, scope_id) in ancestor_scope_ids.into_iter().enumerate() {
             let scope = &self.scopes[scope_id];
-            if scope.kind.is_class() {
+            let is_class = scope.kind.is_class();
+            let is_function = scope.kind.is_function();
+            let uses_star_imports = scope.uses_star_imports();
+            let mut is_name = false;
+
+            if is_class {
                 // Allow usages of `__class__` within methods, e.g.:
                 //
                 // ```python
@@ -430,154 +704,42 @@ impl<'a> SemanticModel<'a> {
             class_variables_visible = scope.kind.is_type() && index == 0;
 
             if let Some(binding_id) = scope.get(name.id.as_str()) {
-                // Mark the binding as used.
-                let reference_id = self.resolved_references.push(
-                    self.scope_id,
-                    self.node_id,
-                    ExprContext::Load,
-                    self.flags,
-                    name.range,
-                );
-                self.bindings[binding_id].references.push(reference_id);
-
-                // Mark any submodule aliases as used.
-                if let Some(binding_id) =
-                    self.resolve_submodule(name.id.as_str(), scope_id, binding_id)
-                {
-                    let reference_id = self.resolved_references.push(
-                        self.scope_id,
-                        self.node_id,
-                        ExprContext::Load,
-                        self.flags,
-                        name.range,
-                    );
-                    self.bindings[binding_id].references.push(reference_id);
+                // Return solved if there is at least one import with a submodule
+                for temp_binding_id in scope.get_all(name.id.as_str()) {
+                    if let BindingKind::Import(_) = &self.bindings[temp_binding_id].kind {
+                        is_name = true;
+                    }
                 }
 
-                match self.bindings[binding_id].kind {
-                    // If it's a type annotation, don't treat it as resolved. For example, given:
-                    //
-                    // ```python
-                    // name: str
-                    // print(name)
-                    // ```
-                    //
-                    // The `name` in `print(name)` should be treated as unresolved, but the `name` in
-                    // `name: str` should be treated as used.
-                    //
-                    // Stub files are an exception. In a stub file, it _is_ considered valid to
-                    // resolve to a type annotation.
-                    BindingKind::Annotation if !self.in_stub_file() => continue,
+                // Todo: Move the implementation here
+                for temp_binding_id in scope.get_all(name.id.as_str()) {
+                    if let BindingKind::SubmoduleImport(_) = &self
+                        .bindings[temp_binding_id].kind {
 
-                    // If it's a deletion, don't treat it as resolved, since the name is now
-                    // unbound. For example, given:
-                    //
-                    // ```python
-                    // x = 1
-                    // del x
-                    // print(x)
-                    // ```
-                    //
-                    // The `x` in `print(x)` should be treated as unresolved.
-                    //
-                    // Similarly, given:
-                    //
-                    // ```python
-                    // try:
-                    //     pass
-                    // except ValueError as x:
-                    //     pass
-                    //
-                    // print(x)
-                    //
-                    // The `x` in `print(x)` should be treated as unresolved.
-                    BindingKind::Deletion | BindingKind::UnboundException(None) => {
-                        self.unresolved_references.push(
-                            name.range,
-                            self.exceptions(),
-                            UnresolvedReferenceFlags::empty(),
-                        );
-                        return ReadResult::UnboundLocal(binding_id);
-                    }
-
-                    BindingKind::ConditionalDeletion(binding_id) => {
-                        self.unresolved_references.push(
-                            name.range,
-                            self.exceptions(),
-                            UnresolvedReferenceFlags::empty(),
-                        );
-                        return ReadResult::UnboundLocal(binding_id);
-                    }
-
-                    // If we hit an unbound exception that shadowed a bound name, resole to the
-                    // bound name. For example, given:
-                    //
-                    // ```python
-                    // x = 1
-                    //
-                    // try:
-                    //     pass
-                    // except ValueError as x:
-                    //     pass
-                    //
-                    // print(x)
-                    // ```
-                    //
-                    // The `x` in `print(x)` should resolve to the `x` in `x = 1`.
-                    BindingKind::UnboundException(Some(binding_id)) => {
-                        // Mark the binding as used.
-                        let reference_id = self.resolved_references.push(
-                            self.scope_id,
-                            self.node_id,
-                            ExprContext::Load,
-                            self.flags,
-                            name.range,
-                        );
-                        self.bindings[binding_id].references.push(reference_id);
-
-                        // Mark any submodule aliases as used.
-                        if let Some(binding_id) =
-                            self.resolve_submodule(name.id.as_str(), scope_id, binding_id)
-                        {
-                            let reference_id = self.resolved_references.push(
-                                self.scope_id,
-                                self.node_id,
-                                ExprContext::Load,
-                                self.flags,
-                                name.range,
-                            );
-                            self.bindings[binding_id].references.push(reference_id);
+                        if !is_name {
+                            return ReadResult::NotFound;
                         }
 
-                        self.resolved_names.insert(name.into(), binding_id);
-                        return ReadResult::Resolved(binding_id);
-                    }
-
-                    BindingKind::Global(Some(binding_id))
-                    | BindingKind::Nonlocal(binding_id, _) => {
-                        // Mark the shadowed binding as used.
-                        let reference_id = self.resolved_references.push(
-                            self.scope_id,
-                            self.node_id,
-                            ExprContext::Load,
-                            self.flags,
-                            name.range,
-                        );
-                        self.bindings[binding_id].references.push(reference_id);
-
-                        // Treat it as resolved.
-                        self.resolved_names.insert(name.into(), binding_id);
-                        return ReadResult::Resolved(binding_id);
-                    }
-
-                    _ => {
-                        // Otherwise, treat it as resolved.
-                        self.resolved_names.insert(name.into(), binding_id);
-                        return ReadResult::Resolved(binding_id);
+                        for reference_id in self.bindings[temp_binding_id].references() {
+                            if self.resolved_references[reference_id].range()
+                                .contains_range(self.bindings[temp_binding_id].range)
+                            {
+                                return ReadResult::Resolved(temp_binding_id);
+                            }
+                        }
                     }
                 }
-            }
 
+                result = self.resolve_binding(
+                    binding_id,
+                    &name,
+                    &scope_id,
+                );
+
+                if !result.is_none() {
+                    return result.unwrap();
+                }
+            }
             // Allow usages of `__module__` and `__qualname__` within class scopes, e.g.:
             //
             // ```python
@@ -593,14 +755,14 @@ impl<'a> SemanticModel<'a> {
             //     __qualname__ = "Bar"
             //     print(__qualname__)
             // ```
-            if index == 0 && scope.kind.is_class() {
+            if index == 0 && is_class {
                 if matches!(name.id.as_str(), "__module__" | "__qualname__") {
                     return ReadResult::ImplicitGlobal;
                 }
             }
 
-            seen_function |= scope.kind.is_function();
-            import_starred = import_starred || scope.uses_star_imports();
+            seen_function |= is_function;
+            import_starred = import_starred || uses_star_imports;
         }
 
         if import_starred {

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -558,6 +558,11 @@ impl<'a> SemanticModel<'a> {
                         return ReadResult::Resolved(binding_id);
                     }
                 }
+                for reference in self.unresolved_references.clone() {
+                    if reference.range().contains_range(name_expr.unwrap().range) {
+                        return ReadResult::NotFound;
+                    }
+                }
             }
         }
 

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -525,6 +525,7 @@ impl<'a> SemanticModel<'a> {
         let mut is_name_exist = false;
         let mut already_checked_imports: HashSet<String> = HashSet::new();
         let mut is_submodule = false;
+        let mut is_no_import = false;
 
         while let Expr::Attribute(expr_attr) = &current_expr {
             full_name = format!("{}.{}", expr_attr.attr.id, full_name);
@@ -548,11 +549,17 @@ impl<'a> SemanticModel<'a> {
         let ancestor_scope_ids: Vec<_> = self.scopes.ancestor_ids(self.scope_id).collect();
         let mut binding_ids: Vec<(BindingId, ScopeId)> = vec![];
 
-        for (_index, scope_id) in ancestor_scope_ids.into_iter().enumerate() {
-            for binding_id in self.scopes[scope_id].get_all(name_expr.unwrap().id.as_str()){
-                binding_ids.push((binding_id, scope_id));
+        for (_index, scope_id) in ancestor_scope_ids.iter().enumerate() {
+            for binding_id in self.scopes[*scope_id].get_all(name_expr.unwrap().id.as_str()){
+                binding_ids.push((binding_id, *scope_id));
                 if let BindingKind::Import(_) = &self.binding(binding_id).kind {
                     is_name_exist = true;
+                }
+                if let BindingKind::Assignment = &self.binding(binding_id).kind {
+                    is_no_import = true;
+                }
+                if let BindingKind::LoopVar = &self.binding(binding_id).kind {
+                    is_no_import = true;
                 }
             }
         }
@@ -629,6 +636,18 @@ impl<'a> SemanticModel<'a> {
             for reference in self.unresolved_references.clone() {
                 if reference.range().contains_range(name_expr.unwrap().range) {
                     return ReadResult::NotFound;
+                }
+            }
+        }
+
+        if is_no_import {
+            for (_index, scope_id) in ancestor_scope_ids.iter().enumerate(){
+                if let Some(binding_id) = self.scopes[*scope_id].get(name_expr.unwrap().id.as_str()) {
+                    result = self.resolve_binding(
+                        binding_id,
+                        &name_expr.unwrap(),
+                        scope_id,
+                    );
                 }
             }
         }

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -551,22 +551,13 @@ impl<'a> SemanticModel<'a> {
         for (_index, scope_id) in ancestor_scope_ids.into_iter().enumerate() {
             for binding_id in self.scopes[scope_id].get_all(name_expr.unwrap().id.as_str()){
                 binding_ids.push((binding_id, scope_id));
-                for reference_id in self.bindings[binding_id].references() {
-                    if self.resolved_references[reference_id].range()
-                        .contains_range(name_expr.unwrap().range)
-                    {
-                        return ReadResult::Resolved(binding_id);
-                    }
-                }
-                for reference in self.unresolved_references.clone() {
-                    if reference.range().contains_range(name_expr.unwrap().range) {
-                        return ReadResult::NotFound;
-                    }
+                if let BindingKind::Import(_) = &self.binding(binding_id).kind {
+                    is_name_exist = true;
                 }
             }
         }
 
-        for i in 2..=parts.len()  {
+        for i in (2..=parts.len()).rev()  {
             let part = parts[..i].join(".");
             for (binding_id, scope_id) in binding_ids.iter() {
                 if let BindingKind::SubmoduleImport(binding_kind) = &self.binding(*binding_id).kind
@@ -580,16 +571,14 @@ impl<'a> SemanticModel<'a> {
                             &name_expr.unwrap(),
                             scope_id,
                         ) {
-                            return result;
+                            if !is_name_exist {
+                                return result;
+                            }
                         }
                     }
                 }
-                if let BindingKind::Import(_) = &self.binding(*binding_id).kind {
-                    is_name_exist = true;
-                }
             }
         }
-
         // TODO: need to move the block implementation to resolve_load, but carefully
         // start check module import
         for (binding_id, scope_id) in binding_ids.iter() {
@@ -628,6 +617,21 @@ impl<'a> SemanticModel<'a> {
             }
         }
         // end check module import
+
+        for (binding_id, _) in binding_ids.iter() {
+            for reference_id in self.bindings[*binding_id].references() {
+                if self.resolved_references[reference_id].range()
+                    .contains_range(name_expr.unwrap().range)
+                {
+                    return ReadResult::Resolved(*binding_id);
+                }
+            }
+            for reference in self.unresolved_references.clone() {
+                if reference.range().contains_range(name_expr.unwrap().range) {
+                    return ReadResult::NotFound;
+                }
+            }
+        }
 
         if result.is_none() {
             if is_submodule {

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -543,6 +543,7 @@ impl<'a> SemanticModel<'a> {
         }
 
         full_name = full_name.trim_end_matches('.').to_string();
+        let parts = full_name.split('.').collect::<Vec<&str>>();
 
         let ancestor_scope_ids: Vec<_> = self.scopes.ancestor_ids(self.scope_id).collect();
         let mut binding_ids: Vec<(BindingId, ScopeId)> = vec![];
@@ -560,42 +561,26 @@ impl<'a> SemanticModel<'a> {
             }
         }
 
-        for (binding_id, scope_id) in binding_ids.iter() {
-            if let BindingKind::SubmoduleImport(binding_kind) = &self.binding(*binding_id).kind
-            {
-                if binding_kind.qualified_name.to_string().contains(name_expr.unwrap().id.as_str()) {
-                    is_submodule = true;
-                }
-                if binding_kind.qualified_name.to_string() == full_name {
-                    if let Some(result) = self.resolve_binding(
-                        *binding_id,
-                        &name_expr.unwrap(),
-                        scope_id,
-                    ) {
-                        return result;
+        for i in 2..=parts.len()  {
+            let part = parts[..i].join(".");
+            for (binding_id, scope_id) in binding_ids.iter() {
+                if let BindingKind::SubmoduleImport(binding_kind) = &self.binding(*binding_id).kind
+                {
+                    if binding_kind.qualified_name.to_string().contains(name_expr.unwrap().id.as_str()) {
+                        is_submodule = true;
+                    }
+                    if binding_kind.qualified_name.to_string() == part {
+                        if let Some(result) = self.resolve_binding(
+                            *binding_id,
+                            &name_expr.unwrap(),
+                            scope_id,
+                        ) {
+                            return result;
+                        }
                     }
                 }
-            }
-            if let BindingKind::Import(_) = &self.binding(*binding_id).kind {
-                is_name_exist = true;
-            }
-        }
-
-        full_name = full_name.rsplit_once(".").map_or(full_name.clone(), |(left, _)| left.to_string());
-        for (binding_id, scope_id) in binding_ids.iter() {
-            if let BindingKind::SubmoduleImport(binding_kind) = &self.binding(*binding_id).kind
-            {
-                if binding_kind.qualified_name.to_string().contains(name_expr.unwrap().id.as_str()) {
-                    is_submodule = true;
-                }
-                if binding_kind.qualified_name.to_string() == full_name {
-                    if let Some(result) = self.resolve_binding(
-                        *binding_id,
-                        &name_expr.unwrap(),
-                        scope_id,
-                    ) {
-                        return result;
-                    }
+                if let BindingKind::Import(_) = &self.binding(*binding_id).kind {
+                    is_name_exist = true;
                 }
             }
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
Mark as unresolved the use of Non-imported submodules.

```
import foo.bar
import foo.baz

fu = foo.ban.asd() # mark as undefined
...
```

## Test Plan

<!-- How was it tested? -->
cargo test